### PR TITLE
Quitar logo, agregar favicon U, mejorar menú móvil

### DIFF
--- a/about.html
+++ b/about.html
@@ -17,6 +17,7 @@
     <meta name="twitter:card" content="summary_large_image" />
 
     <!-- Favicon -->
+    <link rel="icon" type="image/svg+xml" href="favicon.svg">
     <link rel="shortcut icon" href="favicon.ico">
 
     <!-- Google Fonts - Inter -->
@@ -47,13 +48,7 @@
         <!-- Sidebar -->
         <aside id="fh5co-aside" role="complementary" class="border js-fullheight">
             <h1 id="fh5co-logo">
-                <a href="index.html">
-                    <svg class="logo-icon" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
-                        <circle cx="20" cy="20" r="18" stroke="currentColor" stroke-width="2.5" fill="none"/>
-                        <path d="M12 24V18M16 24V14M20 24V16M24 24V12M28 24V17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
-                    </svg>
-                    <span>Unalytics</span>
-                </a>
+                <a href="index.html">Unalytics</a>
             </h1>
 
             <nav id="fh5co-main-menu" role="navigation">

--- a/blog.html
+++ b/blog.html
@@ -15,6 +15,7 @@
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
 
+    <link rel="icon" type="image/svg+xml" href="favicon.svg">
     <link rel="shortcut icon" href="favicon.ico">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -36,13 +37,7 @@
 
         <aside id="fh5co-aside" role="complementary" class="border js-fullheight">
             <h1 id="fh5co-logo">
-                <a href="index.html">
-                    <svg class="logo-icon" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
-                        <circle cx="20" cy="20" r="18" stroke="currentColor" stroke-width="2.5" fill="none"/>
-                        <path d="M12 24V18M16 24V14M20 24V16M24 24V12M28 24V17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
-                    </svg>
-                    <span>Unalytics</span>
-                </a>
+                <a href="index.html">Unalytics</a>
             </h1>
 
             <nav id="fh5co-main-menu" role="navigation">

--- a/contact.html
+++ b/contact.html
@@ -17,6 +17,7 @@
     <meta name="twitter:card" content="summary_large_image" />
 
     <!-- Favicon -->
+    <link rel="icon" type="image/svg+xml" href="favicon.svg">
     <link rel="shortcut icon" href="favicon.ico">
 
     <!-- Google Fonts - Inter -->
@@ -47,13 +48,7 @@
         <!-- Sidebar -->
         <aside id="fh5co-aside" role="complementary" class="border js-fullheight">
             <h1 id="fh5co-logo">
-                <a href="index.html">
-                    <svg class="logo-icon" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
-                        <circle cx="20" cy="20" r="18" stroke="currentColor" stroke-width="2.5" fill="none"/>
-                        <path d="M12 24V18M16 24V14M20 24V16M24 24V12M28 24V17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
-                    </svg>
-                    <span>Unalytics</span>
-                </a>
+                <a href="index.html">Unalytics</a>
             </h1>
 
             <nav id="fh5co-main-menu" role="navigation">

--- a/css/modern.css
+++ b/css/modern.css
@@ -113,10 +113,6 @@ a:hover {
 }
 
 #fh5co-aside #fh5co-logo a {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 12px;
     color: var(--primary);
     font-weight: 700;
     font-size: 28px;
@@ -126,18 +122,6 @@ a:hover {
 }
 
 #fh5co-aside #fh5co-logo a:hover {
-    color: var(--primary-dark);
-}
-
-#fh5co-aside #fh5co-logo .logo-icon {
-    width: 48px;
-    height: 48px;
-    color: var(--primary);
-    transition: all var(--transition-base);
-}
-
-#fh5co-aside #fh5co-logo a:hover .logo-icon {
-    transform: scale(1.05);
     color: var(--primary-dark);
 }
 
@@ -1066,4 +1050,138 @@ body.offcanvas #fh5co-aside {
     color: var(--text-secondary);
     margin: 0;
     line-height: 1.5;
+}
+
+/* === MENU HAMBURGUESA MOBILE === */
+.fh5co-nav-toggle {
+    position: fixed;
+    top: 20px;
+    right: 20px;
+    z-index: 9999;
+    width: 44px;
+    height: 44px;
+    display: none;
+    cursor: pointer;
+    background: var(--primary);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-md);
+}
+
+.fh5co-nav-toggle i {
+    position: relative;
+    display: block;
+    width: 20px;
+    height: 2px;
+    background: var(--white);
+    margin: 0 auto;
+    top: 50%;
+    transform: translateY(-50%);
+    transition: all 0.2s ease;
+}
+
+.fh5co-nav-toggle i::before,
+.fh5co-nav-toggle i::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    width: 20px;
+    height: 2px;
+    background: var(--white);
+    transition: all 0.2s ease;
+}
+
+.fh5co-nav-toggle i::before {
+    top: -6px;
+}
+
+.fh5co-nav-toggle i::after {
+    top: 6px;
+}
+
+.fh5co-nav-toggle:hover {
+    background: var(--primary-dark);
+}
+
+/* Menu abierto */
+.fh5co-nav-toggle.active i {
+    background: transparent;
+}
+
+.fh5co-nav-toggle.active i::before {
+    top: 0;
+    transform: rotate(45deg);
+}
+
+.fh5co-nav-toggle.active i::after {
+    top: 0;
+    transform: rotate(-45deg);
+}
+
+@media screen and (max-width: 768px) {
+    .fh5co-nav-toggle {
+        display: block;
+    }
+
+    #fh5co-aside {
+        transform: translateX(-100%);
+        transition: transform 0.3s ease;
+    }
+
+    body.offcanvas #fh5co-aside {
+        transform: translateX(0);
+    }
+
+    #fh5co-main {
+        width: 100%;
+        margin-left: 0;
+    }
+
+    #fh5co-main .fh5co-narrow-content {
+        padding: 2rem 1.25rem;
+    }
+
+    .features-grid {
+        gap: 12px;
+    }
+
+    .feature-card {
+        padding: 20px 16px;
+    }
+
+    .feature-card .feature-icon {
+        width: 48px;
+        height: 48px;
+    }
+
+    .feature-card .feature-icon i {
+        font-size: 20px;
+    }
+
+    .feature-card h3 {
+        font-size: 14px;
+    }
+
+    .feature-card p {
+        font-size: 12px;
+    }
+
+    .projects-grid {
+        gap: 12px;
+    }
+
+    .project-card .project-img {
+        height: 150px;
+    }
+
+    .project-card .project-content {
+        padding: 16px;
+    }
+
+    .project-card .project-content h3 {
+        font-size: 13px;
+    }
+
+    .project-card .project-content p {
+        font-size: 12px;
+    }
 }

--- a/favicon.svg
+++ b/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#009B3C"/>
+  <text x="16" y="23" font-family="Inter, Arial, sans-serif" font-size="20" font-weight="700" fill="white" text-anchor="middle">U</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
 
+    <link rel="icon" type="image/svg+xml" href="favicon.svg">
     <link rel="shortcut icon" href="favicon.ico">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -36,13 +37,7 @@
 
         <aside id="fh5co-aside" role="complementary" class="border js-fullheight">
             <h1 id="fh5co-logo">
-                <a href="index.html">
-                    <svg class="logo-icon" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
-                        <circle cx="20" cy="20" r="18" stroke="currentColor" stroke-width="2.5" fill="none"/>
-                        <path d="M12 24V18M16 24V14M20 24V16M24 24V12M28 24V17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
-                    </svg>
-                    <span>Unalytics</span>
-                </a>
+                <a href="index.html">Unalytics</a>
             </h1>
 
             <nav id="fh5co-main-menu" role="navigation">

--- a/portfolio.html
+++ b/portfolio.html
@@ -17,6 +17,7 @@
     <meta name="twitter:card" content="summary_large_image" />
 
     <!-- Favicon -->
+    <link rel="icon" type="image/svg+xml" href="favicon.svg">
     <link rel="shortcut icon" href="favicon.ico">
 
     <!-- Google Fonts - Inter -->
@@ -47,13 +48,7 @@
         <!-- Sidebar -->
         <aside id="fh5co-aside" role="complementary" class="border js-fullheight">
             <h1 id="fh5co-logo">
-                <a href="index.html">
-                    <svg class="logo-icon" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
-                        <circle cx="20" cy="20" r="18" stroke="currentColor" stroke-width="2.5" fill="none"/>
-                        <path d="M12 24V18M16 24V14M20 24V16M24 24V12M28 24V17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
-                    </svg>
-                    <span>Unalytics</span>
-                </a>
+                <a href="index.html">Unalytics</a>
             </h1>
 
             <nav id="fh5co-main-menu" role="navigation">


### PR DESCRIPTION
- Eliminado logo SVG, vuelto a texto simple "Unalytics"
- Nuevo favicon SVG con letra "U" verde institucional
- Menú hamburguesa mejorado para móvil
- Estilos responsive optimizados para móvil
- Tarjetas y grids adaptados a pantallas pequeñas

https://claude.ai/code/session_01LDf9aRsoZLJGBakEYERcEJ